### PR TITLE
Add sound dispatch macros and `OptimiseSound` flag; replace direct QueueSound calls with `Music`/`SFX` macros

### DIFF
--- a/Enhancements/Features.asm
+++ b/Enhancements/Features.asm
@@ -201,6 +201,7 @@ TweakConsistantLevelSelectClear:    equ 0 ; Based on https://forums.sonicretro.o
 
 TweakRemoveUselessZ80Commands:      equ 0 ; Based on https://forums.sonicretro.org/index.php?threads/s1-friendly-improved-sonic-2-sound-driver.34249/
 TweakNavigationLevelSelect:         equ 0 ; Based on https://forums.sonicretro.org/index.php?threads/s1-friendly-improved-sonic-2-sound-driver.34249/
+OptimiseSound:                      equ 1 ; 1 = write directly to sound queue RAM instead of calling QueueSound routines
 
 ; @TODO Move Press Start Accordingly too
 

--- a/Enhancements/Features_Original.asm
+++ b/Enhancements/Features_Original.asm
@@ -185,6 +185,7 @@ TweakConsistantLevelSelectClear:    equ 0 ; Based on https://forums.sonicretro.o
 
 TweakRemoveUselessZ80Commands:      equ 0 ; Based on https://forums.sonicretro.org/index.php?threads/s1-friendly-improved-sonic-2-sound-driver.34249/
 TweakNavigationLevelSelect:         equ 0 ; Based on https://forums.sonicretro.org/index.php?threads/s1-friendly-improved-sonic-2-sound-driver.34249/
+OptimiseSound:                      equ 0 ; 1 = write directly to sound queue RAM instead of calling QueueSound routines
 
 ; @TODO Move Press Start Accordingly too
 

--- a/Macros.asm
+++ b/Macros.asm
@@ -291,6 +291,72 @@ out_of_range:	macro exit,pos
 		endm
 
 ; ---------------------------------------------------------------------------
+; play a sound effect or music
+; input: track, queue type, branch/call type, move operand size
+; ---------------------------------------------------------------------------
+
+SoundDispatch_Call:	equ 0
+SoundDispatch_Branch:	equ 1
+sound:		macro track,queue,dispatch
+		if OptimiseSound=0
+			if "\track"<>"d0"
+		move.b	track,d0
+			endif
+			if queue=1
+				if dispatch=SoundDispatch_Branch
+		bsr.w	QueueSound2
+				else
+		jsr	(QueueSound2).l
+				endif
+			else
+				if dispatch=SoundDispatch_Branch
+		bsr.w	QueueSound1
+				else
+		jsr	(QueueSound1).l
+				endif
+			endif
+		else
+			if queue=1
+		move.b	#track,(v_snddriver_ram+zAbsVar.SFXToPlay).l
+			else
+		move.b	#track,(v_snddriver_ram+zAbsVar.QueueToPlay).l
+			endif
+		endif
+		endm
+
+music:		macro track,dispatch
+		sound	\track,0,\dispatch
+		endm
+
+sfx:		macro track,dispatch
+		sound	\track,1,\dispatch
+		endm
+
+QueueMusic:	macro track
+		music	\track,SoundDispatch_Branch
+		endm
+
+Music:		macro track
+		QueueMusic	\track
+		endm
+
+PlayMusic:	macro track
+		music	\track,SoundDispatch_Call
+		endm
+
+QueueSFX:	macro track
+		sfx	\track,SoundDispatch_Branch
+		endm
+
+SFX:		macro track
+		QueueSFX	\track
+		endm
+
+PlaySFX:	macro track
+		sfx	\track,SoundDispatch_Call
+		endm
+
+; ---------------------------------------------------------------------------
 ; bankswitch between SRAM and ROM
 ; (remember to enable SRAM in the header first!)
 ; ---------------------------------------------------------------------------

--- a/REMOVED_2020_IF_GAPS.md
+++ b/REMOVED_2020_IF_GAPS.md
@@ -1,0 +1,19 @@
+# 2020 Feature Regression Scan (post-upstream merge)
+
+Compared `55cee6d` (2020-11-09, last 2020 Cyber Axe commit) to current `HEAD` (`886c9d1`) and scanned removed `if`-condition lines.
+
+## Findings: `if` conditions missing an equivalent toggle symbol
+
+1. **`OptimiseSound` conditional removed with no replacement symbol in current tree**
+   - Removed location in historical diff: `sound/Sonic 1 Sound Driver.asm` (two `if OptimiseSound=1` guards were deleted during upstream merge cleanup).
+   - The symbol definition itself was also removed (`OptimiseSound: equ 0`).
+   - Current status: no symbol named `OptimiseSound` exists at `HEAD`.
+
+2. **`Needed` token appears only in comments from removed lines, not as an active conditional feature**
+   - Appears in removed comment text (`Needed to display code in ram to create tables`) but has no current `if Needed...` feature flag equivalent.
+   - This is not a real feature toggle in 2020 code, just annotation text found in removed hunks.
+
+## Notes
+
+- Most 2020 feature toggles (`Feature*`, `BugFix*`, `Tweak*`, `Enhanced*`) **still exist** in the merged tree, often with renamed files/relocated code.
+- The only concrete removed `if`-flag with no modern equivalent found by this scan is **`OptimiseSound`**.

--- a/_inc/DynamicLevelEvents.asm
+++ b/_inc/DynamicLevelEvents.asm
@@ -179,8 +179,7 @@ DLE_GHZ3_Boss:
 		move.w	#boss_ghz_y-$80,obY(a1)
 
 	.fail:
-		move.w	#bgm_Boss,d0
-		bsr.w	QueueSound1				; play boss music
+		Music	#bgm_Boss				; play boss music
 		move.b	#1,(f_lockscreen).w			; lock screen
 		addq.b	#2,(v_dle_routine).w			; goto DLE_GHZ3_End next
 		moveq	#plcid_Boss,d0
@@ -228,8 +227,7 @@ DLE_LZ3:
 		cmpi.b	#7,(a1)
 		beq.s	.skip_layout				; branch if already modified
 		move.b	#7,(a1)					; modify level layout
-		move.w	#sfx_Rumbling,d0
-		bsr.w	QueueSound2				; play rumbling sound
+		SFX	#sfx_Rumbling				; play rumbling sound
 
 	.skip_layout:
 		tst.b	(v_dle_routine).w
@@ -244,8 +242,7 @@ DLE_LZ3:
 		_move.b	#id_BossLabyrinth,obID(a1)		; load LZ boss object
 
 	.fail:
-		move.w	#bgm_Boss,d0
-		bsr.w	QueueSound1				; play boss music
+		Music	#bgm_Boss				; play boss music
 		move.b	#1,(f_lockscreen).w			; lock screen
 		addq.b	#2,(v_dle_routine).w			; don't load boss again
 		moveq	#plcid_Boss,d0
@@ -452,8 +449,7 @@ DLE_MZ3_Boss:
 		move.w	#boss_mz_y+$1C,obY(a1)
 
 	.fail:
-		move.w	#bgm_Boss,d0
-		bsr.w	QueueSound1				; play boss music
+		Music	#bgm_Boss				; play boss music
 		move.b	#1,(f_lockscreen).w			; lock screen
 		addq.b	#2,(v_dle_routine).w			; goto DLE_MZ3_End next
 		moveq	#plcid_Boss,d0
@@ -524,8 +520,7 @@ DLE_SLZ3_Boss:
 		move.b	#id_BossStarLight,obID(a1)		; load SLZ boss object
 
 	.fail:
-		move.w	#bgm_Boss,d0
-		bsr.w	QueueSound1				; play boss music
+		Music	#bgm_Boss				; play boss music
 		move.b	#1,(f_lockscreen).w			; lock screen
 		addq.b	#2,(v_dle_routine).w			; goto DLE_SLZ3_End next
 		moveq	#plcid_Boss,d0
@@ -618,8 +613,7 @@ DLE_SYZ3_Boss:
 		addq.b	#2,(v_dle_routine).w			; goto DLE_SYZ3_End next
 
 	.fail:
-		move.w	#bgm_Boss,d0
-		bsr.w	QueueSound1				; play boss music
+		Music	#bgm_Boss				; play boss music
 		move.b	#1,(f_lockscreen).w			; lock screen
 		moveq	#plcid_Boss,d0
 		bra.w	AddPLC					; load boss gfx

--- a/_inc/LZWaterFeatures.asm
+++ b/_inc/LZWaterFeatures.asm
@@ -172,8 +172,7 @@ DynWater_LZ3:
 		move.w	#$4C8,d1									; set new water height
 		move.b	#$4B,(v_lvllayout_fg+((layout_row*2)+6)).w ; update chunk at row 2, column 6 (zero-based)
 		move.b	#1,(v_wtr_routine).w 			; use second routine next
-		move.w	#sfx_Rumbling,d0
-		bsr.w	QueueSound2 ; play sound $B7 (rumbling)
+		SFX	#sfx_Rumbling ; play sound $B7 (rumbling)
 
 .setwaterlz3:
 		move.w	d1,(v_waterpos3).w
@@ -314,8 +313,7 @@ LZWindTunnels:
 		move.b	(v_vblank_byte).w,d0
 		andi.b	#$3F,d0										; does VInt counter fall on 0, $40, $80 or $C0?
 		bne.s	.skipsound	; if not, branch
-		move.w	#sfx_Waterfall,d0
-		jsr	(QueueSound2).l	; play rushing water sound (only every $40 frames)
+		SFX	#sfx_Waterfall	; play rushing water sound (only every $40 frames)
 
 .skipsound:
 		tst.b	(f_wtunnelallow).w 					; are wind tunnels disabled?
@@ -436,8 +434,7 @@ loc_3F9A:
 		move.b	(v_vblank_byte).w,d0
 		andi.b	#$1F,d0
 		bne.s	locret_3FBE
-		move.w	#sfx_Waterfall,d0
-		jsr	(QueueSound2).l	; play water sound
+		SFX	#sfx_Waterfall	; play water sound
 
 locret_3FBE:
 		rts

--- a/_incObj/80 & 81 Continue Screen Elements and Sonic.asm
+++ b/_incObj/80 & 81 Continue Screen Elements and Sonic.asm
@@ -158,8 +158,7 @@ CSon_GetUp:
 		move.b	#id_Float4,obAnim(a0) ; use "getting up" animation
 		clr.w	obInertia(a0)
 		subq.w	#8,obY(a0)
-		move.b	#bgm_Fade,d0
-		bsr.w	QueueSound2 ; fade out music
+		Music	#bgm_Fade ; fade out music
 
 CSon_Run:	; Routine 6
 		cmpi.w	#$800,obInertia(a0) ; check Sonic's inertia

--- a/_incObj/sub ResumeMusic.asm
+++ b/_incObj/sub ResumeMusic.asm
@@ -5,24 +5,24 @@
 ResumeMusic:
 		cmpi.w	#12,(v_air).w	; more than 12 seconds of air left?
 		bhi.s	.over12		; if yes, branch
-		move.w	#bgm_LZ,d0	; play LZ music
+		QueueMusic	#bgm_LZ	; play LZ music
 		cmpi.w	#id_LZ_act4,(v_zone).w ; check if level is SBZ3 (LZ4)
 		bne.s	.notsbz
-		move.w	#bgm_SBZ,d0	; play SBZ music
+		QueueMusic	#bgm_SBZ	; play SBZ music
 
 .notsbz:
 	if Revision<>0
 		tst.b	(v_invinc).w ; is Sonic invincible?
 		beq.s	.notinvinc ; if not, branch
-		move.w	#bgm_Invincible,d0
+		QueueMusic	#bgm_Invincible
 .notinvinc:
 		tst.b	(f_lockscreen).w ; is Sonic at a boss?
 		beq.s	.playselected ; if not, branch
-		move.w	#bgm_Boss,d0
+		QueueMusic	#bgm_Boss
 .playselected:
 	endif
 
-		jsr	(QueueSound1).l
+		PlayMusic	d0
 
 .over12:
 		move.w	#30,(v_air).w	; reset air to 30 seconds

--- a/sonic.asm
+++ b/sonic.asm
@@ -1930,10 +1930,9 @@ GM_Sega:
 		; fading out from previous game mode
 
 	if FeatureUseSonic2SoundDriver=0
-		move.b	#bgm_Stop,d0			; set stop music command
-		bsr.w	QueueSound2			; stop music
+		Music	#bgm_Stop			; stop music
 	else
-		music	bgm_Stop,0,1,1 ; stop music
+		Music	#bgm_Stop ; stop music
 	endif ; if FeatureUseSonic2SoundDriver=0
 		bsr.w	ClearPLC			; stop any potential in-progress PLC
 
@@ -2019,8 +2018,7 @@ Sega_WaitPal:	; while light scanning effect is active
 ; ---------------------------------------------------------------------------
 
 		; while "SEGA" sound is playing
-		move.b	#sfx_Sega,d0			; set "SEGA" sound
-		bsr.w	QueueSound2			; queue it
+		SFX	#sfx_Sega			; queue "SEGA" sound
 
 	if FeatureUseSonic2SoundDriver=0
 		move.b	#id_VBlank_SegaPCM,(v_vblank_routine).w ; set VBlank routine to $14
@@ -2068,10 +2066,9 @@ Sega_GotoTitle:	; transition to title screen
 ; TitleScreen:
 GM_Title:	; fading out from previous game mode
 	if FeatureUseSonic2SoundDriver=0
-		move.b	#bgm_Stop,d0		; set stop music command
-		bsr.w	QueueSound2			; stop music
+		Music	#bgm_Stop		; stop music
 	else
-		music	bgm_Stop,0,1,1 													; stop music
+		Music	#bgm_Stop 													; stop music
 	endif ; if FeatureUseSonic2SoundDriver=0
 
 		bsr.w	ClearPLC			; stop any potential in-progress PLC
@@ -2210,8 +2207,7 @@ Tit_LoadText:
 
 		moveq	#palid_Title,d0			; load title screen palette...
 		bsr.w	PalLoad_Fade			; ...to fade-in buffer
-		move.b	#bgm_Title,d0			; set title screen music
-		bsr.w	QueueSound2			; play title screen music
+		Music	#bgm_Title			; play title screen music
 		move.b	#0,(f_debugmode).w		; disable debug mode (cheat remains active though)
 		move.w	#376,(v_generictimer).w		; run title screen for 376 frames (6 seconds plus some change)
 
@@ -2342,8 +2338,7 @@ Tit_ActivateCheat:
 
 Tit_PlayRing:
 		move.b	#1,(a0,d1.w)			; activate cheat depending on C-press count
-		move.b	#sfx_Ring,d0			; set ring sound when code is entered
-		bsr.w	QueueSound2			; play it
+		SFX	#sfx_Ring			; play ring sound when code is entered
 		bra.s	Tit_CountC			; skip over cheat reset
 ; ===========================================================================
 
@@ -2493,7 +2488,7 @@ LevSel_NoCheat:
 LevSel_PlaySnd:
 	endif
 
-		bsr.w	QueueSound2			; play selected sound
+		SFX	d0			; play selected sound
 		bra.s	LevelSelect			; loop level select
 ; ===========================================================================
 
@@ -2505,8 +2500,7 @@ LevSel_Ending:
 
 LevSel_Credits:
 		move.b	#id_Credits,(v_gamemode).w	; set screen mode to $1C (Credits)
-		move.b	#bgm_Credits,d0			; set credits music
-		bsr.w	QueueSound2			; play it
+		Music	#bgm_Credits			; play credits music
 		move.w	#0,(v_creditsnum).w		; start at the first credits page
 		rts
 ; ===========================================================================
@@ -2579,8 +2573,7 @@ PlayLevel:
 	if Revision<>0
 		move.l	#5000,(v_scorelife).w		; extra life is awarded at 50000 points
 	endif
-		move.b	#bgm_Fade,d0			; set music fade-out command
-		bsr.w	QueueSound2			; fade out music
+		Music	#bgm_Fade			; fade out music
 		rts					; return to MainGameLoop to start level
 ; End of function GM_Title
 
@@ -2689,8 +2682,7 @@ GotoDemo_ChkLoop:
 ; ---------------------------------------------------------------------------
 
 		; start loading demo now
-		move.b	#bgm_Fade,d0			; set music fade-out command
-		bsr.w	QueueSound2			; fade out music
+		Music	#bgm_Fade			; fade out music
 
 		move.w	(v_demonum).w,d0		; load demo number
 		andi.w	#7,d0				; limit to four demo entries
@@ -3204,8 +3196,7 @@ GM_Level:	; fading out from previous game mode
 		tst.b    (f_levelreload).w
 		bne.w    Level_NoMusicFade
 	endif ; if TweakFastLevelReload
-		move.b	#bgm_Fade,d0			; queue music fade-out command
-		bsr.w	QueueSound2			; fade out music
+		Music	#bgm_Fade			; fade out music
 
 Level_NoMusicFade:
 		bsr.w	ClearPLC			; clear any remaining PLC entries
@@ -3349,7 +3340,7 @@ Level_BgmNotLZ4:
 Level_PlayBgm:
 		lea	(MusicList).l,a1		; load music playlist
 		move.b	(a1,d0.w),d0			; get music ID for current level
-		bsr.w	QueueSound1			; play music
+		Music	d0			; play music
 		move.b	#id_TitleCard,(v_titlecard).w	; load title card object
 	if TweakNoWaitingonPLCForLevelTiles
 	  move.w  #3,v_framecount.w      																		; set the timer (Fixes Title card bug)
@@ -3787,8 +3778,7 @@ Demo_SS:	include	"demodata/Intro - Special Stage.asm"
 
 ; SpecialStage:
 GM_Special:	; white fade-out from previous game mode
-		move.w	#sfx_EnterSS,d0			; set special stage entry sound
-		bsr.w	QueueSound2			; play it
+		SFX	#sfx_EnterSS			; play special stage entry sound
 		bsr.w	PaletteWhiteOut			; fade-out to white
 ; ---------------------------------------------------------------------------
 
@@ -3826,7 +3816,7 @@ GM_Special:	; white fade-out from previous game mode
 		clr.w	(v_ssangle).w			; set stage angle to "upright"
 		move.w	#$40,(v_ssrotate).w		; set stage rotation speed
 		move.w	#bgm_SS,d0			; play special stage BG music
-		bsr.w	QueueSound1			; play it
+		PlayMusic	d0			; play it
 
 		move.w	#0,(v_btnpushtime1).w		; clear button push counters for demos
 		lea	(DemoDataPtr).l,a1		; load demo data
@@ -3972,7 +3962,7 @@ SS_FinLoop_NoBrighten:
 		move.w	d0,(v_ringbonus).w		; set rings bonus
 
 		move.w	#bgm_GotThrough,d0		; play end-of-level music
-		jsr	(QueueSound2).l	 		; play it
+		Music	d0			; play it
 
 		clearRAM v_objspace			; clear object RAM
 
@@ -3994,7 +3984,7 @@ SS_NormalExit:	; Special Stage results screen loop
 
 		; Exit Special Stage normally
 		move.w	#sfx_EnterSS,d0			; play special stage exit sound
-		bsr.w	QueueSound2 			; play it
+		SFX	d0			; play it
 		bsr.w	PaletteWhiteOut			; fade-out to white
 		rts					; return to MainGameLoop
 ; ===========================================================================
@@ -4068,7 +4058,7 @@ GM_Continue:
 		moveq	#palid_Continue,d0		; load continue screen palette...
 		bsr.w	PalLoad_Fade			; ...into fade-in buffer
 		move.b	#bgm_Continue,d0		; play continue screen music
-		bsr.w	QueueSound1			; play it
+		Music	d0			; play it
 
 		move.w	#659,(v_generictimer).w		; show continue screen for 11 seconds in total
 
@@ -4156,10 +4146,9 @@ Cont_GotoLevel:
 GM_Ending:
 	if FeatureUseSonic2SoundDriver=0
 		; fading out from previous game mode
-		move.b	#bgm_Stop,d0			; set stop music command
-		bsr.w	QueueSound2			; stop music
+		Music	#bgm_Stop			; stop music
 	else
-		music	bgm_Stop,0,1,1 ; stop music
+		Music	#bgm_Stop ; stop music
 	endif
 		bsr.w	PaletteFadeOut			; fade-out previous game mode
 ; ---------------------------------------------------------------------------
@@ -4222,7 +4211,7 @@ End_LoadData:
 		moveq	#palid_Sonic,d0			; load Sonic's palette...
 		bsr.w	PalLoad_Fade			; ...to fade-in buffer
 		move.w	#bgm_Ending,d0			; play ending sequence music
-		bsr.w	QueueSound1			; play it
+		Music	d0			; play it
 
 	if (BugFixFZDebugCreditTransition)|(FixBugs)
 		; Fix being able to enable debug mode without having entered the cheat code for it
@@ -4300,7 +4289,7 @@ End_MainLoop:
 
 		move.b	#id_Credits,(v_gamemode).w	; change game mode to credits
 		move.b	#bgm_Credits,d0			; play credits music
-		bsr.w	QueueSound2			; play it
+		Music	d0			; play it
 		move.w	#0,(v_creditsnum).w		; set credits page number to 0 ("Sonic Team Staff")
 		rts					; return to MainGameLoop
 ; ===========================================================================


### PR DESCRIPTION
### Motivation
- Introduce an abstraction for playing music and SFX to support optimized sound queuing and to centralize sound dispatch behavior via a feature flag `OptimiseSound`.
- Replace numerous ad-hoc `move` + `bsr.w/jsr (QueueSound*)` callsites with a single macro interface to simplify code and enable a mode that writes directly to sound queue RAM.
- Record a brief regression-scan note about a removed historical `OptimiseSound` conditional in `REMOVED_2020_IF_GAPS.md`.

### Description
- Add a new feature toggle `OptimiseSound` in `Enhancements/Features.asm` (set to `1`) and `Enhancements/Features_Original.asm` (set to `0`).
- Implement new sound/musics macros in `Macros.asm` including `sound`, `music`, `sfx`, `Music`, `SFX`, `QueueMusic`, `PlayMusic`, `QueueSFX`, `PlaySFX` and constants `SoundDispatch_Call`/`SoundDispatch_Branch` that branch between legacy queuing and direct RAM writes when `OptimiseSound` is enabled.
- Replace many direct sound calls across the codebase (examples include `_inc/DynamicLevelEvents.asm`, `_inc/LZWaterFeatures.asm`, `_incObj/80 & 81 Continue Screen Elements and Sonic.asm`, `_incObj/sub ResumeMusic.asm`, and `sonic.asm`) by using the new macros (for example replacing `move.w #bgm_Boss,d0` + `bsr.w QueueSound1` with `Music #bgm_Boss`, and `move.w #sfx_Rumbling,d0` + `bsr.w QueueSound2` with `SFX #sfx_Rumbling`).
- Add `REMOVED_2020_IF_GAPS.md` documenting the 2020 feature-regression scan finding related to `OptimiseSound`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a073b8479248324b5a713e30a2311fa)